### PR TITLE
Add client module for communication, materials, payments, and notifications

### DIFF
--- a/python_backend/src/api/__init__.py
+++ b/python_backend/src/api/__init__.py
@@ -47,6 +47,13 @@ except Exception as e:
     schedule_router = None
 
 try:
+    from .client_module import router as client_router
+    print("✅ Client module router imported")
+except Exception as e:
+    print(f"❌ Error importing client module router: {e}")
+    client_router = None
+
+try:
     from .users import router as users_router
     print("✅ Users router imported")
 except Exception as e:
@@ -114,6 +121,12 @@ def create_api_router() -> APIRouter:
         print("✅ Schedule router included")
     else:
         print("⚠️  Schedule router skipped (import failed)")
+
+    if client_router:
+        api_router.include_router(client_router, tags=["client"])
+        print("✅ Client module router included")
+    else:
+        print("⚠️  Client module router skipped (import failed)")
     
     if users_router:
         try:

--- a/python_backend/src/api/client_module.py
+++ b/python_backend/src/api/client_module.py
@@ -1,0 +1,128 @@
+from typing import List
+from fastapi import APIRouter, HTTPException, status
+from datetime import datetime
+import uuid
+
+from src.database.client_repository import ClientModuleRepository
+from src.models import (
+    ForumMessage,
+    Installment,
+    Issue,
+    IssueCreate,
+    MaterialItem,
+    NotificationSetting,
+    FrequencyUnit,
+)
+
+
+router = APIRouter()
+repo = ClientModuleRepository()
+
+
+@router.post("/projects/{project_id}/issues", response_model=Issue)
+async def create_issue(project_id: str, issue: IssueCreate) -> Issue:
+    if project_id != issue.project_id:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Project ID mismatch",
+        )
+    return await repo.create_issue(issue)
+
+
+@router.get("/projects/{project_id}/issues", response_model=List[Issue])
+async def list_issues(project_id: str) -> List[Issue]:
+    return await repo.list_issues(project_id)
+
+
+@router.patch("/issues/{issue_id}", response_model=Issue)
+async def close_issue(issue_id: str) -> Issue:
+    issue = await repo.close_issue(issue_id)
+    if not issue:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Issue not found")
+    return issue
+
+
+@router.post("/projects/{project_id}/forum", response_model=ForumMessage)
+async def add_forum_message(
+    project_id: str, author_id: str, content: str
+) -> ForumMessage:
+    return await repo.add_forum_message(project_id, author_id, content)
+
+
+@router.get("/projects/{project_id}/forum", response_model=List[ForumMessage])
+async def list_forum_messages(project_id: str) -> List[ForumMessage]:
+    return await repo.list_forum_messages(project_id)
+
+
+@router.post("/projects/{project_id}/materials", response_model=MaterialItem)
+async def add_material(project_id: str, name: str, added_by: str, link: str | None = None,
+                       specification: str | None = None) -> MaterialItem:
+    item = MaterialItem(
+        id=str(uuid.uuid4()),
+        project_id=project_id,
+        name=name,
+        link=link,
+        specification=specification,
+        added_by=added_by,
+        created_at=datetime.utcnow(),
+    )
+    return await repo.add_material(item)
+
+
+@router.delete("/materials/{material_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def remove_material(material_id: str) -> None:
+    await repo.remove_material(material_id)
+
+
+@router.get("/projects/{project_id}/materials", response_model=List[MaterialItem])
+async def list_materials(project_id: str) -> List[MaterialItem]:
+    return await repo.list_materials(project_id)
+
+
+@router.post("/projects/{project_id}/installments", response_model=Installment)
+async def add_installment(project_id: str, amount: float, due_date: datetime) -> Installment:
+    installment = Installment(
+        id=str(uuid.uuid4()),
+        project_id=project_id,
+        amount=amount,
+        due_date=due_date,
+        is_paid=False,
+        payment_method=None,
+        created_at=datetime.utcnow(),
+    )
+    return await repo.add_installment(installment)
+
+
+@router.patch("/installments/{installment_id}", response_model=Installment)
+async def mark_installment_paid(installment_id: str, payment_method: str) -> Installment:
+    inst = await repo.mark_installment_paid(installment_id, payment_method)
+    if not inst:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Installment not found")
+    return inst
+
+
+@router.post("/projects/{project_id}/notifications", response_model=NotificationSetting)
+async def set_notification(
+    project_id: str,
+    frequency_value: int,
+    frequency_unit: FrequencyUnit,
+    material_id: str | None = None,
+    group_name: str | None = None,
+    notify_via_email: bool = True,
+) -> NotificationSetting:
+    setting = NotificationSetting(
+        id=str(uuid.uuid4()),
+        project_id=project_id,
+        material_id=material_id,
+        group_name=group_name,
+        frequency_value=frequency_value,
+        frequency_unit=frequency_unit,
+        notify_via_email=notify_via_email,
+        created_at=datetime.utcnow(),
+    )
+    return await repo.set_notification(setting)
+
+
+@router.get("/projects/{project_id}/notifications", response_model=List[NotificationSetting])
+async def list_notifications(project_id: str) -> List[NotificationSetting]:
+    return await repo.list_notifications(project_id)

--- a/python_backend/src/database/client_repository.py
+++ b/python_backend/src/database/client_repository.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from typing import Dict, List
+
+from src.models import (
+    ForumMessage,
+    Installment,
+    Issue,
+    IssueCreate,
+    MaterialItem,
+    NotificationSetting,
+)
+
+
+class ClientModuleRepository:
+    """In-memory repository for client related operations.
+
+    The existing application relies on a database, however for this module we
+    provide an in-memory implementation so the rest of the system can interact
+    with well defined async methods without requiring additional infrastructure.
+    """
+
+    def __init__(self) -> None:
+        self.issues: Dict[str, Issue] = {}
+        self.forum_messages: List[ForumMessage] = []
+        self.materials: Dict[str, MaterialItem] = {}
+        self.installments: Dict[str, Installment] = {}
+        self.notification_settings: Dict[str, NotificationSetting] = {}
+
+    async def create_issue(self, issue: IssueCreate) -> Issue:
+        issue_id = str(uuid.uuid4())
+        new_issue = Issue(
+            id=issue_id,
+            project_id=issue.project_id,
+            title=issue.title,
+            description=issue.description,
+            photos=issue.photos,
+            created_by=issue.created_by,
+            status="open",
+            created_at=datetime.utcnow(),
+        )
+        self.issues[issue_id] = new_issue
+        return new_issue
+
+    async def list_issues(self, project_id: str) -> List[Issue]:
+        return [i for i in self.issues.values() if i.project_id == project_id]
+
+    async def close_issue(self, issue_id: str) -> Issue | None:
+        issue = self.issues.get(issue_id)
+        if issue:
+            issue.status = "closed"  # type: ignore[assignment]
+        return issue
+
+    async def add_forum_message(
+        self, project_id: str, author_id: str, content: str
+    ) -> ForumMessage:
+        message = ForumMessage(
+            id=str(uuid.uuid4()),
+            project_id=project_id,
+            author_id=author_id,
+            content=content,
+            created_at=datetime.utcnow(),
+        )
+        self.forum_messages.append(message)
+        return message
+
+    async def list_forum_messages(self, project_id: str) -> List[ForumMessage]:
+        return [m for m in self.forum_messages if m.project_id == project_id]
+
+    async def add_material(self, item: MaterialItem) -> MaterialItem:
+        self.materials[item.id] = item
+        return item
+
+    async def remove_material(self, material_id: str) -> None:
+        self.materials.pop(material_id, None)
+
+    async def list_materials(self, project_id: str) -> List[MaterialItem]:
+        return [m for m in self.materials.values() if m.project_id == project_id]
+
+    async def add_installment(self, installment: Installment) -> Installment:
+        self.installments[installment.id] = installment
+        return installment
+
+    async def mark_installment_paid(
+        self, installment_id: str, payment_method: str
+    ) -> Installment | None:
+        inst = self.installments.get(installment_id)
+        if inst:
+            inst.is_paid = True  # type: ignore[assignment]
+            inst.payment_method = payment_method
+        return inst
+
+    async def list_installments(self, project_id: str) -> List[Installment]:
+        return [i for i in self.installments.values() if i.project_id == project_id]
+
+    async def set_notification(self, setting: NotificationSetting) -> NotificationSetting:
+        self.notification_settings[setting.id] = setting
+        return setting
+
+    async def list_notifications(self, project_id: str) -> List[NotificationSetting]:
+        return [n for n in self.notification_settings.values() if n.project_id == project_id]
+

--- a/python_backend/src/models/__init__.py
+++ b/python_backend/src/models/__init__.py
@@ -9,6 +9,7 @@ from .photo import *
 from .log import *
 from .notification import *
 from .schedule_change import *
+from .client_module import *
 
 __all__ = [
     # Base models
@@ -55,7 +56,18 @@ __all__ = [
     "NotificationUpdate",
     
     # Schedule change models
-    "ScheduleChange",
+    "ScheduleChange", 
     "ScheduleChangeCreate",
     "ScheduleChangeUpdate",
+
+    # Client module models
+    "IssueStatus",
+    "IssueBase",
+    "IssueCreate",
+    "Issue",
+    "ForumMessage",
+    "MaterialItem",
+    "Installment",
+    "FrequencyUnit",
+    "NotificationSetting",
 ]

--- a/python_backend/src/models/client_module.py
+++ b/python_backend/src/models/client_module.py
@@ -1,0 +1,90 @@
+from datetime import datetime
+from enum import Enum
+from typing import List, Optional
+from pydantic import BaseModel, Field, validator
+from .base import BaseEntity
+
+
+class IssueStatus(str, Enum):
+    """Status for issues reported by a client."""
+    open = "open"
+    closed = "closed"
+
+
+class IssueBase(BaseModel):
+    """Shared attributes for a client reported issue."""
+    project_id: str = Field(alias="projectId")
+    title: str
+    description: str = ""
+    photos: List[str] = []
+
+    @validator("photos")
+    def limit_photos(cls, v: List[str]) -> List[str]:
+        if len(v) > 3:
+            raise ValueError("A maximum of three photos is allowed")
+        return v
+
+
+class IssueCreate(IssueBase):
+    """Model used when a client creates a new issue."""
+    created_by: str = Field(alias="createdBy")
+
+
+class Issue(IssueBase, BaseEntity):
+    """Full representation of an issue."""
+    created_by: str = Field(alias="createdBy")
+    status: IssueStatus = IssueStatus.open
+
+
+class ForumMessage(BaseEntity):
+    """Messages exchanged between clients and project managers."""
+    project_id: str = Field(alias="projectId")
+    author_id: str = Field(alias="authorId")
+    content: str
+
+
+class MaterialItem(BaseEntity):
+    """Item within the collaborative material list."""
+    project_id: str = Field(alias="projectId")
+    name: str
+    link: Optional[str] = None
+    specification: Optional[str] = None
+    added_by: str = Field(alias="addedBy")
+
+
+class Installment(BaseEntity):
+    """Represents a payment installment for a project."""
+    project_id: str = Field(alias="projectId")
+    amount: float
+    due_date: datetime = Field(alias="dueDate")
+    is_paid: bool = Field(default=False, alias="isPaid")
+    payment_method: Optional[str] = Field(default=None, alias="paymentMethod")
+
+
+class FrequencyUnit(str, Enum):
+    day = "day"
+    week = "week"
+    month = "month"
+
+
+class NotificationSetting(BaseEntity):
+    """Notification preferences for material items."""
+    project_id: str = Field(alias="projectId")
+    material_id: Optional[str] = Field(default=None, alias="materialId")
+    group_name: Optional[str] = Field(default=None, alias="groupName")
+    frequency_value: int = Field(alias="frequencyValue")
+    frequency_unit: FrequencyUnit = Field(alias="frequencyUnit")
+    notify_via_email: bool = Field(default=True, alias="notifyViaEmail")
+
+
+__all__ = [
+    "IssueStatus",
+    "IssueBase",
+    "IssueCreate",
+    "Issue",
+    "ForumMessage",
+    "MaterialItem",
+    "Installment",
+    "FrequencyUnit",
+    "NotificationSetting",
+]


### PR DESCRIPTION
## Summary
- implement client module models for issues, forum, materials, installments, and notification settings
- add in-memory repository and API routes for client interactions
- integrate client module router into FastAPI application

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b20a229c70832d8149abd71e437b81