### PR TITLE
Ensure Python backend stays alive with keep-alive supervisor

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,17 @@ Project management app for the construction industry
 - Role-based permissions<br>
 - Email with daily tasks
 
+## Development
+
+### Backend
+
+Run the FastAPI backend with automatic restart and heartbeat checks:
+
+```bash
+./start_backend.sh
+```
+
+This script uses `python_backend/keep_alive.py` to restart the server if it
+crashes and to periodically ping the `/health` endpoint so hosting platforms do
+not suspend the process due to inactivity.
+

--- a/python_backend/keep_alive.py
+++ b/python_backend/keep_alive.py
@@ -1,19 +1,57 @@
 #!/usr/bin/env python3
-"""
-Keep the Python FastAPI backend alive with automatic restart.
-This ensures the backend stays running for continuous frontend connectivity.
+"""Utility to keep the FastAPI backend alive.
+
+The original project relied on the hosting environment to keep the Python
+process running.  When the environment became less stable we added this small
+supervisor that starts the backend, restarts it on failure and periodically
+performs a simple health check.  The health check pings the backend which helps
+prevent certain platforms (such as Replit) from suspending the instance due to
+inactivity.  The script has no external dependencies and can be executed from
+any working directory.
 """
 
+from pathlib import Path
 import subprocess
+import threading
 import time
 import os
 import signal
 import sys
 
+# `requests` is optional; fall back to urllib if it's unavailable.
+try:
+    import requests  # type: ignore
+except Exception:  # pragma: no cover - optional dependency
+    requests = None  # type: ignore
+import urllib.request
+
+# Resolve the project directory so the script can be launched from anywhere
+BASE_DIR = Path(__file__).resolve().parent
+os.chdir(BASE_DIR)
+
 BACKEND_SCRIPT = "main.py"
-LOG_FILE = "backend.log"
 MAX_RESTARTS = 10
 RESTART_DELAY = 2
+HEARTBEAT_INTERVAL = 25  # seconds
+
+
+def heartbeat(stop_event: threading.Event) -> None:
+    """Continuously ping the backend health endpoint.
+
+    Some development environments pause containers that do not receive traffic.
+    By sending a request every few seconds we keep the process marked as active
+    and detect when the server stops responding.
+    """
+    while not stop_event.is_set():
+        try:
+            if requests:
+                requests.get("http://localhost:8000/health", timeout=5)
+            else:  # Fallback using urllib
+                urllib.request.urlopen("http://localhost:8000/health", timeout=5).read()
+        except Exception:
+            # Ignore connectivity errors; the monitor loop handles restarts.
+            pass
+        stop_event.wait(HEARTBEAT_INTERVAL)
 
 def signal_handler(sig, frame):
     print("🛑 Gracefully shutting down backend...")
@@ -34,9 +72,14 @@ def keep_backend_alive():
                 stdout=subprocess.PIPE,
                 stderr=subprocess.STDOUT,
                 universal_newlines=True,
-                bufsize=1
+                bufsize=1,
             )
-            
+
+            # Start heartbeat thread to keep environment active
+            stop_event = threading.Event()
+            hb_thread = threading.Thread(target=heartbeat, args=(stop_event,), daemon=True)
+            hb_thread.start()
+
             # Monitor the process
             while True:
                 line = process.stdout.readline()
@@ -44,16 +87,25 @@ def keep_backend_alive():
                     print(line.strip())
                     if "Uvicorn running" in line:
                         print("✅ Backend successfully started and running!")
-                
+
                 # Check if process is still running
                 if process.poll() is not None:
                     print(f"⚠️ Backend process terminated with code {process.returncode}")
                     break
-                    
+
                 time.sleep(0.1)
-            
+
+            # Stop heartbeat when process exits
+            stop_event.set()
+            hb_thread.join(timeout=1)
+
         except KeyboardInterrupt:
             print("🛑 Interrupted by user")
+            try:
+                stop_event.set()
+                hb_thread.join(timeout=1)
+            except Exception:
+                pass
             if process and process.poll() is None:
                 process.terminate()
             break

--- a/python_backend/requirements.txt
+++ b/python_backend/requirements.txt
@@ -4,3 +4,5 @@ asyncpg==0.29.0
 pydantic==2.5.0
 python-multipart==0.0.6
 python-dotenv==1.0.0
+requests==2.31.0
+

--- a/start_backend.sh
+++ b/start_backend.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+# Start the backend using the keep_alive supervisor so the process restarts
+# automatically and sends periodic heartbeats.
 cd python_backend
-echo "🚀 Starting Python FastAPI backend..."
-exec uvicorn main:app --host 0.0.0.0 --port 8000 --log-level debug --workers 1
+echo "🚀 Starting Python FastAPI backend with keep-alive..."
+exec python keep_alive.py
+

--- a/start_python_backend.sh
+++ b/start_python_backend.sh
@@ -3,9 +3,10 @@ echo "🐍 Starting Python FastAPI backend..."
 
 cd python_backend
 
-# Kill any existing Python processes
-pkill -f "python main.py" 2>/dev/null || true
+# Kill any existing backend processes
+pkill -f "keep_alive.py" 2>/dev/null || true
 sleep 2
 
-# Start Python backend with error handling
-exec python main.py 2>&1
+# Start Python backend via supervisor with auto-restart
+exec python keep_alive.py 2>&1
+


### PR DESCRIPTION
## Summary
- add keep_alive supervisor that restarts backend and pings health endpoint
- update start scripts to use keep_alive and document usage
- include requests in requirements with graceful fallback

## Testing
- `pip install -q -r python_backend/requirements.txt` *(failed: Could not find a version that satisfies the requirement requests==2.31.0)*
- `pytest -q` *(failed: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_68b3594cc208832d8f6dfe9048294e11